### PR TITLE
Caches error that cannot be logged

### DIFF
--- a/Elmah.Io/ErrorLog.cs
+++ b/Elmah.Io/ErrorLog.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Web;
-using System.Web.Hosting;
 using Mannex;
 using Mannex.Threading.Tasks;
 using Mannex.Web;


### PR DESCRIPTION
Error that for some reason cannot be logged to the elmah.io backend, are now cached in App_Data. Everytime the server creates a new ErrorLog, the client will try to log the errors not previously logged and delete them from App_Data.
